### PR TITLE
feat:make init実行時にteasテーブルの内容を一度全削除する処理を追加

### DIFF
--- a/ent/client.go
+++ b/ent/client.go
@@ -28,9 +28,7 @@ type Client struct {
 
 // NewClient creates a new client configured with the given options.
 func NewClient(opts ...Option) *Client {
-	cfg := config{log: log.Println, hooks: &hooks{}, inters: &inters{}}
-	cfg.options(opts...)
-	client := &Client{config: cfg}
+	client := &Client{config: newConfig(opts...)}
 	client.init()
 	return client
 }
@@ -57,6 +55,13 @@ type (
 	// Option function to configure the client.
 	Option func(*config)
 )
+
+// newConfig creates a new config for the client.
+func newConfig(opts ...Option) config {
+	cfg := config{log: log.Println, hooks: &hooks{}, inters: &inters{}}
+	cfg.options(opts...)
+	return cfg
+}
 
 // options applies the options on the config object.
 func (c *config) options(opts ...Option) {

--- a/ent/runtime/runtime.go
+++ b/ent/runtime/runtime.go
@@ -5,6 +5,6 @@ package runtime
 // The schema-stitching logic is generated in github.com/tkanata/embulk-hands-on-postgresql2csv/ent/runtime.go
 
 const (
-	Version = "v0.12.4"                                         // Version of ent codegen.
-	Sum     = "h1:LddPnAyxls/O7DTXZvUGDj0NZIdGSu317+aoNLJWbD8=" // Sum of ent codegen.
+	Version = "v0.12.5"                                         // Version of ent codegen.
+	Sum     = "h1:KREM5E4CSoej4zeGa88Ou/gfturAnpUv0mzAjch1sj4=" // Sum of ent codegen.
 )

--- a/ent/tea_update.go
+++ b/ent/tea_update.go
@@ -33,9 +33,25 @@ func (tu *TeaUpdate) SetName(s string) *TeaUpdate {
 	return tu
 }
 
+// SetNillableName sets the "name" field if the given value is not nil.
+func (tu *TeaUpdate) SetNillableName(s *string) *TeaUpdate {
+	if s != nil {
+		tu.SetName(*s)
+	}
+	return tu
+}
+
 // SetColor sets the "color" field.
 func (tu *TeaUpdate) SetColor(s string) *TeaUpdate {
 	tu.mutation.SetColor(s)
+	return tu
+}
+
+// SetNillableColor sets the "color" field if the given value is not nil.
+func (tu *TeaUpdate) SetNillableColor(s *string) *TeaUpdate {
+	if s != nil {
+		tu.SetColor(*s)
+	}
 	return tu
 }
 
@@ -112,9 +128,25 @@ func (tuo *TeaUpdateOne) SetName(s string) *TeaUpdateOne {
 	return tuo
 }
 
+// SetNillableName sets the "name" field if the given value is not nil.
+func (tuo *TeaUpdateOne) SetNillableName(s *string) *TeaUpdateOne {
+	if s != nil {
+		tuo.SetName(*s)
+	}
+	return tuo
+}
+
 // SetColor sets the "color" field.
 func (tuo *TeaUpdateOne) SetColor(s string) *TeaUpdateOne {
 	tuo.mutation.SetColor(s)
+	return tuo
+}
+
+// SetNillableColor sets the "color" field if the given value is not nil.
+func (tuo *TeaUpdateOne) SetNillableColor(s *string) *TeaUpdateOne {
+	if s != nil {
+		tuo.SetColor(*s)
+	}
 	return tuo
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/tkanata/embulk-hands-on-postgresql2csv
 go 1.20
 
 require (
-	entgo.io/ent v0.12.4
+	entgo.io/ent v0.12.5
 	github.com/lib/pq v1.10.9
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ ariga.io/atlas v0.14.1-0.20230918065911-83ad451a4935 h1:JnYs/y8RJ3+MiIUp+3RgyyeO
 ariga.io/atlas v0.14.1-0.20230918065911-83ad451a4935/go.mod h1:isZrlzJ5cpoCoKFoY9knZug7Lq4pP1cm8g3XciLZ0Pw=
 entgo.io/ent v0.12.4 h1:LddPnAyxls/O7DTXZvUGDj0NZIdGSu317+aoNLJWbD8=
 entgo.io/ent v0.12.4/go.mod h1:Y3JVAjtlIk8xVZYSn3t3mf8xlZIn5SAOXZQxD6kKI+Q=
+entgo.io/ent v0.12.5 h1:KREM5E4CSoej4zeGa88Ou/gfturAnpUv0mzAjch1sj4=
+entgo.io/ent v0.12.5/go.mod h1:Y3JVAjtlIk8xVZYSn3t3mf8xlZIn5SAOXZQxD6kKI+Q=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/main.go
+++ b/main.go
@@ -19,6 +19,33 @@ func main() {
 	}
 	defer db.Close()
 
+	// テーブルから全てのレコードを削除
+	fmt.Println("Deleting all existing records from the 'teas' table...")
+	_, err = db.Exec("DELETE FROM teas")
+	if err != nil {
+		panic(err)  // エラーがあればここでパニックを起こす
+	}
+	fmt.Println("All existing records have been deleted.")
+
+
+  // 既存のIDを取得してセットに保存
+	existingIDs := make(map[string]bool)
+	rows, err := db.Query("SELECT id FROM teas")
+	if err != nil {
+		panic(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			panic(err)
+		}
+		existingIDs[id] = true
+	}
+	if err := rows.Err(); err != nil {
+		panic(err)
+	}
+
 	// CSV ファイルを開く
 	f, err := os.Open("teas.csv")
 	if err != nil {
@@ -33,7 +60,7 @@ func main() {
 		panic(err)
 	}
 
-	// ヘッダー行をスキップするため、1から始める
+  // ヘッダー行をスキップするため、1から始める
 	for _, record := range records[1:] {
 		id := record[0]
 		name := record[1]
@@ -45,5 +72,7 @@ func main() {
 		}
 	}
 
+	
 	fmt.Println("Data imported successfully!")
 }
+


### PR DESCRIPTION
main.goにteasテーブルの内容をdeleteする処理を追加。
これによって重複するidが存在する場合にmain.goがエラーを吐く状況を改善。